### PR TITLE
Add TotalBytesUsed to ContainerMemoryStat

### DIFF
--- a/container.go
+++ b/container.go
@@ -267,6 +267,9 @@ type ContainerMemoryStat struct {
 	TotalInactiveFile       uint64
 	TotalActiveFile         uint64
 	TotalUnevictable        uint64
+	// A memory usage total which reports memory usage in the same way that limits are enforced.
+	// This value includes memory consumed by nested containers.
+	TotalUsageTowardLimit uint64
 }
 
 type ContainerCPUStat struct {


### PR DESCRIPTION
Windows has a very different breakdown of memory, adding a Total gives us a field to share between linux and windows

[#94104582]

Signed-off-by: Dave_Goddard <dgoddard@pivotal.io>