### PR TITLE
fixes handles splitting so an empty string is split into an empty slice

### DIFF
--- a/server/request_handling.go
+++ b/server/request_handling.go
@@ -1048,7 +1048,7 @@ func (s *GardenServer) handleInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *GardenServer) handleBulkInfo(w http.ResponseWriter, r *http.Request) {
-	handles := strings.Split(r.URL.Query()["handles"][0], ",")
+	handles := splitHandles(r.URL.Query()["handles"][0])
 
 	hLog := s.logger.Session("bulk_info", lager.Data{
 		"handles": handles,
@@ -1067,7 +1067,7 @@ func (s *GardenServer) handleBulkInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *GardenServer) handleBulkMetrics(w http.ResponseWriter, r *http.Request) {
-	handles := strings.Split(r.URL.Query()["handles"][0], ",")
+	handles := splitHandles(r.URL.Query()["handles"][0])
 
 	hLog := s.logger.Session("bulk_metrics", lager.Data{
 		"handles": handles,
@@ -1219,4 +1219,12 @@ func (s *GardenServer) streamProcess(logger lager.Logger, conn net.Conn, process
 			return
 		}
 	}
+}
+
+func splitHandles(queryHandles string) []string {
+	handles := []string{}
+	if queryHandles != "" {
+		handles = strings.Split(queryHandles, ",")
+	}
+	return handles
 }

--- a/server/request_handling_test.go
+++ b/server/request_handling_test.go
@@ -1575,6 +1575,13 @@ var _ = Describe("When a client connects", func() {
 				},
 			}
 
+			It("calls BulkInfo with empty slice when handles is empty", func() {
+				handles = nil
+				serverBackend.BulkInfoReturns(nil, nil)
+				apiClient.BulkInfo(handles)
+				Expect(serverBackend.BulkInfoArgsForCall(0)).To(BeEmpty())
+			})
+
 			It("reports information about containers by list of handles", func() {
 				serverBackend.BulkInfoReturns(expectedBulkInfo, nil)
 
@@ -1645,6 +1652,13 @@ var _ = Describe("When a client connects", func() {
 				bulkMetrics, err := apiClient.BulkMetrics(handles)
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(bulkMetrics).To(Equal(expectedBulkMetrics))
+			})
+
+			It("calls BulkMetrics with empty slice when handles is empty", func() {
+				handles = nil
+				serverBackend.BulkMetricsReturns(nil, nil)
+				apiClient.BulkMetrics(handles)
+				Expect(serverBackend.BulkMetricsArgsForCall(0)).To(BeEmpty())
 			})
 
 			Context("when retrieving bulk info fails", func() {


### PR DESCRIPTION
We found that garden incorrectly convert the query parameter `handlers=` to a slice that has an empty string. this commit fixes this bug and adds tests.

/cc @julz 

Signed-off-by: John Shahid <jshahid@pivotal.io>