### PR TITLE
client: Add DNSServers field to ContainerSpec

### DIFF
--- a/client.go
+++ b/client.go
@@ -128,6 +128,12 @@ type ContainerSpec struct {
 	//   already had a container allocated from it.
 	Network string `json:"network,omitempty"`
 
+	// DNSServers is a list of IP addresses to use as an override for DNS servers in the container.
+	//
+	// If not specified, the DNS servers in use by the host will be copied over. If specified, DNS
+	// servers used by the host are ignored.
+	DNSServers []string `json:"dns_servers,omitempty"`
+
 	// Properties is a sequence of string key/value pairs providing arbitrary
 	// data about the container. The keys are assumed to be unique but this is not
 	// enforced via the protocol.


### PR DESCRIPTION
This is used to allow created containers to use a specific set of DNS servers, rather than relying on the hosts's `/etc/resolv.conf`.  Useful in configurations where the host DNS server is inappropriate (e.g. localhost without being exposed on other interfaces).

See also cloudfoundry-incubator/garden-linux#60.

This will have matching PRs in `guardian` and `guardian-release`, followed by a second PR in the garden family to implement the same.